### PR TITLE
Update ruby to 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN npm -v
 # Install GEM dependencies
 RUN gem update --system 3.1.4 \
  && gem install \
-      bundler:2.0.2 \
+      bundler:2.2.11 \
       foreman:0.84.0
 
 # Persist IRB/Pry/Rails console history

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.3
+FROM ruby:2.7.2
 
 LABEL maintainer "Kyero <dev@kyero.com>"
 
@@ -49,7 +49,7 @@ RUN node -v
 RUN npm -v
 
 # Install GEM dependencies
-RUN gem update --system 3.0.2 \
+RUN gem update --system 3.1.4 \
  && gem install \
       bundler:2.0.2 \
       foreman:0.84.0


### PR DESCRIPTION
this PR updates ruby to 2.7

Note: we're aware that ruby 3 brings JIT and a lot of additional speed, but that's not optimised for rails yet